### PR TITLE
Issue44

### DIFF
--- a/src/fit_changedetector/diff.py
+++ b/src/fit_changedetector/diff.py
@@ -13,9 +13,39 @@ from shapely.geometry.multipolygon import MultiPolygon
 from shapely.geometry.point import Point
 from shapely.geometry.polygon import Polygon
 
+import pyogrio
+
 import fit_changedetector as fcd
 
 LOG = logging.getLogger(__name__)
+
+# Mapping from numpy integer dtypes to pandas nullable equivalents.
+# When a nullable integer column is read via geopandas/pyogrio, nulls force
+# an upcast to float64. Casting to the pandas nullable type restores fidelity.
+_NULLABLE_INT_MAP = {
+    "int8": "Int8",
+    "int16": "Int16",
+    "int32": "Int32",
+    "int64": "Int64",
+}
+
+
+def _cast_dtypes(df, path, layer=None):
+    """Cast *df* columns to match source types using pandas nullable dtypes.
+
+    Uses pyogrio.read_info to retrieve the original field types from *path*/*layer*
+    and re-casts any integer columns that were upcast to float due to null values.
+    """
+    kw = {"layer": layer} if layer else {}
+    info = pyogrio.read_info(path, **kw)
+    src_dtypes = dict(zip(info["fields"], info["dtypes"]))
+    for col, src_dtype in src_dtypes.items():
+        if col not in df.columns:
+            continue
+        target = _NULLABLE_INT_MAP.get(str(src_dtype))
+        if target and str(df[col].dtype) != target:
+            df[col] = df[col].astype(target)
+    return df
 
 
 def promote_to_multi(df):
@@ -497,8 +527,8 @@ def compare(
     src_b = os.path.join(file_b, layer_b or "")
 
     # load source data
-    df_a = geopandas.read_file(file_a, layer=layer_a)
-    df_b = geopandas.read_file(file_b, layer=layer_b)
+    df_a = _cast_dtypes(geopandas.read_file(file_a, layer=layer_a), file_a, layer_a)
+    df_b = _cast_dtypes(geopandas.read_file(file_b, layer=layer_b), file_b, layer_b)
 
     # promote mixed single/multipart features to multipart
     # (shapefiles can have mixed types, but the .gdb driver does not accept this)

--- a/tests/test_diffs.py
+++ b/tests/test_diffs.py
@@ -1,4 +1,7 @@
+import json
+
 import geopandas
+import pandas
 import pytest
 from geopandas import GeoDataFrame
 from shapely.geometry import Point
@@ -229,6 +232,29 @@ def test_precision():
     ]
     assert len(diff_high_precision) == 2
     assert len(diff_low_precision) == 0
+
+
+def test_nullable_integer_columns(tmp_path):
+    """Integer columns containing nulls should be cast to pandas nullable Int types, not float64."""
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "properties": {"id": 1, "count": 5},    "geometry": {"type": "Point", "coordinates": [0, 0]}},
+            {"type": "Feature", "properties": {"id": 2, "count": None}, "geometry": {"type": "Point", "coordinates": [1, 1]}},
+        ],
+    }
+    path = tmp_path / "nullable_int.geojson"
+    path.write_text(json.dumps(geojson))
+
+    df = geopandas.read_file(str(path))
+    # Without fix: null forces integer column to float64
+    assert df["count"].dtype == "float64"
+
+    from fit_changedetector.diff import _cast_dtypes
+    df = _cast_dtypes(df, str(path))
+    # After fix: column should be nullable Int32, null preserved
+    assert df["count"].dtype == "Int32"
+    assert pandas.isna(df.loc[df["id"] == 2, "count"].iloc[0])
 
 
 def test_invalid_diff_precision(gdf):


### PR DESCRIPTION
Uses pyogrio.read_info to detect integer fields that were upcast to float64 due to null values, and restores them to the correct pandas nullable type (Int8/Int16/Int32/Int64).